### PR TITLE
fix: added protobuf constraint to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ tornado>=6.4.1
 uvicorn>=0.13.4
 urllib3>=1.26.5
 httpx>=0.27.0
+protobuf<=6.30.2


### PR DESCRIPTION
Setting a upper bound version to prevent the error 

`google.protobuf.runtime_version.VersionError: Detected mismatched Protobuf Gencode/Runtime version suffixes when loading stan.proto: gencode 5.27.2 runtime 6.31.0-rc2. Version suffixes must be the same. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.`